### PR TITLE
fix: jobs deployment -> build

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 jobs:
-  deployment:
+  build:
     name: CD
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
The workflow must contain at least one job with no dependencies.